### PR TITLE
Curator Updates

### DIFF
--- a/etc/cron.d/curator-close
+++ b/etc/cron.d/curator-close
@@ -4,4 +4,5 @@
 
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-0 1 * * * root docker exec so-curator curator --config /etc/curator/config/curator.yml --dry-run /etc/curator/action/close.yml > /dev/null 2>&1
+
+* * * * * root /usr/sbin/so-elastic-configure-curator-close > /dev/null 2>&1; docker exec so-curator curator --config /etc/curator/config/curator.yml /etc/curator/action/close.yml > /dev/null 2>&1

--- a/etc/cron.d/curator-delete
+++ b/etc/cron.d/curator-delete
@@ -4,4 +4,5 @@
 
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-* * * * * root docker exec so-curator curator --config /etc/curator/config/curator.yml /etc/curator/action/delete.yml > /dev/null 2>&1
+
+* * * * * root /usr/sbin/so-elastic-configure-curator-delete > /dev/null 2>&1; docker exec so-curator curator --config /etc/curator/config/curator.yml /etc/curator/action/delete.yml > /dev/null 2>&1

--- a/etc/curator/action/close.yml
+++ b/etc/curator/action/close.yml
@@ -12,6 +12,7 @@ actions:
       Close indices older than 2 days (based on index name), for logstash-
       prefixed indices.
     options:
+      ignore_empty_list: True
       delete_aliases: False
       timeout_override:
       continue_if_exception: False

--- a/etc/securityonion-elastic.conf
+++ b/etc/securityonion-elastic.conf
@@ -32,7 +32,9 @@ ELASTALERT_OPTIONS=""
 
 # Curator options
 CURATOR_ENABLED="yes"
+CURATOR_CLOSE_DAYS=30
 CURATOR_OPTIONS=""
+
 
 # Freq_server default options
 FREQ_SERVER_ENABLED="no"

--- a/usr/sbin/so-elastic-configure-curator
+++ b/usr/sbin/so-elastic-configure-curator
@@ -4,10 +4,6 @@
 . /etc/nsm/securityonion.conf
 
 header "Configuring Curator"
-
-CURATOR_DEL="/etc/curator/action/delete.yml"
-
-if [ -f $CURATOR_DEL ]; then
-	sed -i "s/disk_space:.*/disk_space: $LOG_SIZE_LIMIT/" $CURATOR_DEL
-fi
+. /usr/sbin/so-elastic-configure-curator-delete
+. /usr/sbin/so-elastic-configure-curator-close
 echo "Done!"

--- a/usr/sbin/so-elastic-configure-curator-close
+++ b/usr/sbin/so-elastic-configure-curator-close
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+. /usr/sbin/so-elastic-common
+. /etc/nsm/securityonion.conf
+
+CURATOR_CLOSE="/etc/curator/action/close.yml"
+
+if [ -f $CURATOR_CLOSE ]; then
+        sed -i "s/Close indices older than.* days/Close indices older than $CURATOR_CLOSE_DAYS days/" $CURATOR_CLOSE
+        sed -i "s/unit_count:.*/unit_count: $CURATOR_CLOSE_DAYS/" $CURATOR_CLOSE
+fi
+

--- a/usr/sbin/so-elastic-configure-curator-delete
+++ b/usr/sbin/so-elastic-configure-curator-delete
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+. /usr/sbin/so-elastic-common
+. /etc/nsm/securityonion.conf
+
+CURATOR_DEL="/etc/curator/action/delete.yml"
+
+if [ -f $CURATOR_DEL ]; then
+        sed -i "s/disk_space:.*/disk_space: $LOG_SIZE_LIMIT/" $CURATOR_DEL
+fi


### PR DESCRIPTION
- add new option to /etc/nsm/securityonion.conf called CURATOR_CLOSE_DAYS (via /usr/sbin/so-elastic-configure-stack and securityonion-elastic.conf) and default to 30
-  update so-elastic-configure-curator to update /etc/curator/action/close.yml with CURATOR_CLOSE_DAYS
-  remove --dry-run from /etc/cron.d/curator-close
-  update /etc/cron.d/curator-close to copy CURATOR_CLOSE_DAYS into config before running curator
-  update /etc/cron.d/curator-delete to copy LOG_SIZE_LIMIT into config before running curator
- add /usr/sbin/so-elastic-configure-curator-close
- add /usr/sbin/so-elastic-configure-curator-delete
- ignore empty lists for Curator close action