### PR TITLE
Modify so-import-pcap and corresponding Logstash Bro file input configuration to use unique subdirectories

### DIFF
--- a/configfiles/0007_input_import.conf
+++ b/configfiles/0007_input_import.conf
@@ -3,172 +3,172 @@
 
 input {
 	file {
-		path => "/nsm/import/bro/conn*"
+		path => "/nsm/import/bro/**/conn*"
 		type => "bro_conn"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/dce_rpc*"
+		path => "/nsm/import/bro/**/dce_rpc*"
 		type => "bro_dce_rpc"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/dhcp*"
+		path => "/nsm/import/bro/**/dhcp*"
 		type => "bro_dhcp"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/dnp3*"
+		path => "/nsm/import/bro/**/dnp3*"
 		type => "bro_dnp3"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/dns*"
+		path => "/nsm/import/bro/**/dns*"
 		type => "bro_dns"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/dpd*"
+		path => "/nsm/import/bro/**/dpd*"
 		type => "bro_dpd"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/files*"
+		path => "/nsm/import/bro/**/files*"
 		type => "bro_files"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/ftp*"
+		path => "/nsm/import/bro/**/ftp*"
 		type => "bro_ftp"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/http*"
+		path => "/nsm/import/bro/**/http*"
 		type => "bro_http"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/intel*"
+		path => "/nsm/import/bro/**/intel*"
 		type => "bro_intel"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/irc*"
+		path => "/nsm/import/bro/**/irc*"
 		type => "bro_irc"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/kerberos*"
+		path => "/nsm/import/bro/**/kerberos*"
 		type => "bro_kerberos"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/modbus*"
+		path => "/nsm/import/bro/**/modbus*"
 		type => "bro_modbus"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/mysql*"
+		path => "/nsm/import/bro/**/mysql*"
 		type => "bro_mysql"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/notice*"
+		path => "/nsm/import/bro/**/notice*"
 		type => "bro_notice"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/ntlm*"
+		path => "/nsm/import/bro/**/ntlm*"
 		type => "bro_ntlm"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/pe*"
+		path => "/nsm/import/bro/**/pe*"
 		type => "bro_pe"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/radius*"
+		path => "/nsm/import/bro/**/radius*"
 		type => "bro_radius"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/rdp*"
+		path => "/nsm/import/bro/**/rdp*"
 		type => "bro_rdp"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/rfb*"
+		path => "/nsm/import/bro/**/rfb*"
 		type => "bro_rfb"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/signatures*"
+		path => "/nsm/import/bro/**/signatures*"
 		type => "bro_signatures"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/sip*"
+		path => "/nsm/import/bro/**/sip*"
 		type => "bro_sip"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/smb_files*"
+		path => "/nsm/import/bro/**/smb_files*"
 		type => "bro_smb_files"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/smb_mapping*"
+		path => "/nsm/import/bro/**/smb_mapping*"
 		type => "bro_smb_mapping"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/smtp*"
+		path => "/nsm/import/bro/**/smtp*"
 		type => "bro_smtp"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/snmp*"
+		path => "/nsm/import/bro/**/snmp*"
 		type => "bro_snmp"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/socks*"
+		path => "/nsm/import/bro/**/socks*"
 		type => "bro_socks"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/software*"
+		path => "/nsm/import/bro/**/software*"
 		type => "bro_software"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/ssh*"
+		path => "/nsm/import/bro/**/ssh*"
 		type => "bro_ssh"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/ssl*"
+		path => "/nsm/import/bro/**/ssl*"
 		type => "bro_ssl"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/syslog*"
+		path => "/nsm/import/bro/**/syslog*"
 		type => "bro_syslog"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/tunnel*"
+		path => "/nsm/import/bro/**/tunnel*"
 		type => "bro_tunnels"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/weird*"
+		path => "/nsm/import/bro/**/weird*"
 		type => "bro_weird"
 	    	tags => ["bro", "import"]
 	}
 	file {
-		path => "/nsm/import/bro/x509*"
+		path => "/nsm/import/bro/**/x509*"
 		type => "bro_x509"
 	    	tags => ["bro", "import"]
 	}

--- a/usr/sbin/so-import-pcap
+++ b/usr/sbin/so-import-pcap
@@ -278,11 +278,14 @@ else
 	suricata --user sguil --group sguil -c /etc/nsm/$SENSOR/suricata.yaml -l /nsm/sensor_data/$SENSOR --runmode single -r $PCAP >/dev/null 2>&1
 fi
 
-# generate Bro logs and write them to /nsm/import/bro/
+# generate Bro logs and write them to a unique subdirectory in /nsm/import/bro/
 BRODIR="/nsm/import/bro"
 echo "...analyzing traffic with Bro."
 mkdir -p $BRODIR
-cd $BRODIR
+BROLOGDIR=$(mktemp -d -p $BRODIR -t bro-XXXXXXXX)
+chown $(stat $BRODIR -c %u:%g) $BROLOGDIR
+chmod $(stat $BRODIR -c %a) $BROLOGDIR
+cd $BROLOGDIR
 /opt/bro/bin/bro -r $PCAP local >/dev/null 2>&1
 cd - >/dev/null
 


### PR DESCRIPTION
When iterating through multiple PCAP files doing imports with so-import-pcap, I occasionally notice errors in /var/log/logstash/logstash.log indicating that Logstash is getting confused about things (JSON parse errors) when I delete the log files in /nsm/import/bro then re-run Bro on a new PCAP file.

This very minor patch tells logstash to look recursively in /nsm/import/bro, and adjusts so-import-pcap to generate each run of Bro's output in a different subdirectory in /nsm/import/bro.