### PR TITLE
provide option to tail log after Elasticsearch/Logstash start

### DIFF
--- a/usr/sbin/so-elasticsearch-restart
+++ b/usr/sbin/so-elasticsearch-restart
@@ -15,5 +15,40 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#########################################
+# Options
+#########################################
+usage()
+{
+cat <<EOF
+Restart Elasticsearch
+  Options:
+  -h         This message
+  -v         Tail the Elasticsearch log after starting
+
+EOF
+}
+
+while getopts "h:v" OPTION
+do
+        case $OPTION in
+                h)
+                        usage
+                        exit 0
+                        ;;
+                v)
+                        TAIL=1
+                        ;;
+                *)
+                        usage
+                        exit 0
+                        ;;
+        esac
+done
+
 /usr/sbin/so-elasticsearch-stop
-/usr/sbin/so-elasticsearch-start
+if [[ "$TAIL" == 1 ]]; then
+        /usr/sbin/so-elasticsearch-start -v
+else
+        /usr/sbin/so-elasticsearch-start
+fi

--- a/usr/sbin/so-elasticsearch-start
+++ b/usr/sbin/so-elasticsearch-start
@@ -19,6 +19,39 @@
 
 . /etc/nsm/securityonion.conf
 
+LOG="/var/log/elasticsearch/$(hostname).log"
+
+#########################################
+# Options
+#########################################
+usage()
+{
+cat <<EOF
+Start Elasticsearch
+  Options:
+  -h         This message
+  -v         Tail the Elasticsearch log after starting
+
+EOF
+}
+
+while getopts "h:v" OPTION
+do
+        case $OPTION in
+                h)
+                        usage
+                        exit 0
+                        ;;
+                v)
+                        TAIL=1
+                        ;;
+                *)
+                        usage
+                        exit 0
+                        ;;
+        esac
+done
+
 if [ "$ELASTICSEARCH_ENABLED" = "yes" ]; then
         echo -n "so-elasticsearch: "
 
@@ -48,5 +81,10 @@ if [ "$ELASTICSEARCH_ENABLED" = "yes" ]; then
 
 		# Other containers will connect to Elasticsearch over $DOCKERNET
 		docker network connect --alias elasticsearch $DOCKERNET so-elasticsearch
-        fi
+        	
+		# Tail log if -v option provided
+                if [[ "$TAIL" == 1 ]]; then
+                        tail -f $LOG
+                fi
+	fi
 fi

--- a/usr/sbin/so-logstash-restart
+++ b/usr/sbin/so-logstash-restart
@@ -15,5 +15,40 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#########################################
+# Options
+#########################################
+usage()
+{
+cat <<EOF
+Restart Logtash
+  Options:
+  -h         This message
+  -v         Tail the Logstash log after starting
+
+EOF
+}
+
+while getopts "h:v" OPTION
+do
+        case $OPTION in
+                h)
+                        usage
+                        exit 0
+                        ;;
+                v)
+                        TAIL=1
+                        ;;
+                *)
+                        usage
+                        exit 0
+                        ;;
+        esac
+done
+
 /usr/sbin/so-logstash-stop
-/usr/sbin/so-logstash-start
+if [[ "$TAIL" == 1 ]]; then
+	/usr/sbin/so-logstash-start -v
+else
+	/usr/sbin/so-logstash-start
+fi

--- a/usr/sbin/so-logstash-start
+++ b/usr/sbin/so-logstash-start
@@ -23,6 +23,39 @@ CUSTOM_CONF="/etc/logstash/custom"
 INPUT_REDIS_CONF="/etc/logstash/conf.d/0900_input_redis.conf"
 OUTPUT_REDIS_CONF="/etc/logstash/conf.d.redis.output/9999_output_redis.conf"
 CONFD="/etc/logstash/conf.d"
+LOG="/var/log/logstash/logstash.log"
+
+#########################################
+# Options
+#########################################
+usage()
+{
+cat <<EOF
+Start Logtash
+  Options:
+  -h         This message
+  -v         Tail the Logstash log after starting
+
+EOF
+}
+
+while getopts "h:v" OPTION
+do
+        case $OPTION in
+                h)
+                        usage
+                        exit 0
+                        ;;
+                v)
+                        TAIL=1
+                        ;;
+                *)
+                        usage
+                        exit 0
+                        ;;
+        esac
+done
+
 
 if [ "$LOGSTASH_ENABLED" = "yes" ]; then
         echo -n "so-logstash: "
@@ -143,5 +176,10 @@ EOF
 
 		# logstash will connect to elasticsearch, domainstats, and freqserver over $DOCKERNET
 		docker network connect --alias logstash $DOCKERNET so-logstash
-        fi
+        	
+		# Tail log if -v option provided
+		if [[ "$TAIL" == 1 ]]; then
+			tail -f $LOG
+		fi
+	fi
 fi


### PR DESCRIPTION
Tail ES/LS log after starting by issuing:

`sudo so-logstash-start -v`
`sudo so-logstash-restart -v`
`sudo so-elasticsearch-start -v`
`sudo so-elasticsearch-restart -v`