### PR TITLE
minor script fixes

### DIFF
--- a/usr/sbin/so-elasticsearch-template-add
+++ b/usr/sbin/so-elasticsearch-template-add
@@ -37,7 +37,7 @@ Add Elasticsearch Template
 EOF
 }
 
-while getopts "h:t:s:" OPTION
+while getopts "ht:s:" OPTION
 do
         case $OPTION in
                 h)

--- a/usr/sbin/so-elasticsearch-template-create
+++ b/usr/sbin/so-elasticsearch-template-create
@@ -100,7 +100,7 @@ cat << EOF > $DFILE
        "properties":{
 EOF
 
-  if [ $KEYWORD == "YES" ]; then
+  if [[ $KEYWORD == "YES" ]]; then
 	  KEYWORD=1
   fi
   if [[ $KEYWORD = 1 ]]; then

--- a/usr/sbin/so-elasticsearch-template-create
+++ b/usr/sbin/so-elasticsearch-template-create
@@ -43,7 +43,7 @@ Create Elasticsearch Template
 EOF
 }
 
-while getopts "h:c:d:i:ko:s:" OPTION
+while getopts "hc:d:i:ko:s:" OPTION
 do
         case $OPTION in
                 h)

--- a/usr/sbin/so-elasticsearch-template-remove
+++ b/usr/sbin/so-elasticsearch-template-remove
@@ -38,7 +38,7 @@ Remove Elasticsearch Template
 EOF
 }
 
-while getopts "h:t:" OPTION
+while getopts "ht:" OPTION
 do
         case $OPTION in
                 h)

--- a/usr/sbin/so-logstash-restart
+++ b/usr/sbin/so-logstash-restart
@@ -29,7 +29,7 @@ Restart Logtash
 EOF
 }
 
-while getopts "h:v" OPTION
+while getopts "hv" OPTION
 do
         case $OPTION in
                 h)

--- a/usr/sbin/so-logstash-start
+++ b/usr/sbin/so-logstash-start
@@ -39,7 +39,7 @@ Start Logtash
 EOF
 }
 
-while getopts "h:v" OPTION
+while getopts "hv" OPTION
 do
         case $OPTION in
                 h)


### PR DESCRIPTION
-Remove required arg for help message for several `so-*`scripts.
-Fix unary operator error for `so-elasticsearch-template-create` when keyword not used.