### PR TITLE
Delete closed Curator indices by disk space

### DIFF
--- a/etc/cron.d/curator-close
+++ b/etc/cron.d/curator-close
@@ -5,4 +5,4 @@
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-* * * * * root /usr/sbin/so-elastic-configure-curator-close > /dev/null 2>&1; docker exec so-curator curator --config /etc/curator/config/curator.yml /etc/curator/action/close.yml > /dev/null 2>&1
+* * * * * root /usr/sbin/so-elastic-configure-curator-close > /dev/null 2>&1; /usr/sbin/so-curator-closed-delete > /dev/null 2>&1; docker exec so-curator curator --config /etc/curator/config/curator.yml /etc/curator/action/close.yml > /dev/null 2>&1

--- a/usr/sbin/so-curator-closed-delete
+++ b/usr/sbin/so-curator-closed-delete
@@ -12,7 +12,7 @@ while [[ "$usage_gb" -ge "$LOG_SIZE_LIMIT" ]]; do
 	
 	# Create an array for index key and name
 	declare -A indices
-	for i in $(curl -s ${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/_cat/indices | grep close | sort -n | awk '{print $2 "|" $3}'); do
+	for i in $(curl -s ${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/_cat/indices | grep -E '^[ \t]+close.*' | sort -n | awk '{print $2 "|" $3}'); do
 		iname=$(echo $i | awk -F'[|]' '{print $1}')
 		iid=$(echo $i | awk -F'[|]' '{print $2}')
 		indices[$iid]=$iname

--- a/usr/sbin/so-curator-closed-delete
+++ b/usr/sbin/so-curator-closed-delete
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+. /usr/sbin/so-elastic-common
+. /etc/nsm/securityonion.conf
+
+#LOG_SIZE_LIMIT=1
+log="/var/log/nsm/so-curator-closed-delete.log"
+index_usage=$(du -s /nsm/elasticsearch/nodes/0/indices | awk '{print $1}')
+usage_gb=$(($index_usage / 10**6))
+
+while [[ "$usage_gb" -ge "$LOG_SIZE_LIMIT" ]]; do
+	
+	# Create an array for index key and name
+	declare -A indices
+	for i in $(curl -s ${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/_cat/indices | grep close | sort -n | awk '{print $2 "|" $3}'); do
+		iname=$(echo $i | awk -F'[|]' '{print $1}')
+		iid=$(echo $i | awk -F'[|]' '{print $2}')
+		indices[$iid]=$iname
+	done
+
+	# Find oldest files in index directories, and compile an array with index key and file epoch
+	declare -A ifiles 
+	for i in ${!indices[@]}; do
+		oldest_file=$(find /nsm/elasticsearch/nodes/0/indices/$i/0/index/ -type f -printf "%C@\n"  | sort | head -n 1)
+		ifiles[$oldest_file]=$i
+	done
+
+	# Sort files and retrieve the oldest
+	ifilesort=($(for i in ${!ifiles[@]}; do echo $i; done | sort)) 
+	filetime=$(echo ${ifilesort})	
+	
+	# Get index id from filetime
+	index_id=${ifiles[${filetime}]}
+	
+	# Get index name from index id 
+	index_name=${indices[${index_id}]}
+	#echo $index_name
+	#echo $index_id
+
+	# Delete index
+	curl -s -XDELETE ${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/$index_name
+	if [ ! -f "$log" ];then
+	    touch $log
+        fi
+
+	# Write to log	
+        echo "$(date) - $usage_gb GB used...exceeds LOG_SIZE_LIMIT ($LOG_SIZE_LIMIT GB) - Index $index_name deleted ..." >> $log
+	
+	# Unset arrays in case we have to run again
+	unset indices
+	unset ifiles
+	unset ifilesort
+	
+done
+if [[ "$usage_gb" -lt "$LOG_SIZE_LIMIT" ]]; then
+  if [ ! -f "$log" ];then
+    touch $log
+  fi
+  echo "$(date) - $usage_gb GB used...less than LOG_SIZE_LIMIT ($LOG_SIZE_LIMIT GB), so not deleting anything." >> $log
+fi
+
+


### PR DESCRIPTION
- Added `so-curator-closed-delete`
- Modified `/etc/cron.d/curator-close` to run `/usr/sbin/so-curator-closed-delete` in conjunction with the close process to delete the oldest closed indices while indices (`$usage_gb`) consume greater than `$LOG_SIZE_LIMIT` in disk space.

Ref: https://github.com/Security-Onion-Solutions/security-onion/issues/1340 