### PR TITLE
do not write ossec/ossec_archive/ids/firewall events to logstash-sysl…

### DIFF
--- a/configfiles/1001_preprocess_syslogng.conf
+++ b/configfiles/1001_preprocess_syslogng.conf
@@ -24,9 +24,9 @@ filter {
 		mutate {
 			add_tag => [ "bro" ]
 		}
-	} else if [type] !~ "ossec" {
+	} else if [type] !~ /ossec.*|snort/ and "firewall" not in [tags] {
 		mutate {
-			add_tag => [ "syslog"]
+			add_tag => [ "syslog" ]
 		}
 	}
   }


### PR DESCRIPTION
Remove `syslog` tag for certain events so they are not written to the  `logstash-syslog-*` index.

- OSSEC Alerts/OSSEC Archive (type of `ossec`, `ossec_archive`)
- IDS (type of `snort`)
- Firewall (`firewall` tag)