### PR TITLE
securityonion-elastic: add script to provide Redis queue count

### DIFF
--- a/usr/sbin/so-redis-count
+++ b/usr/sbin/so-redis-count
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright 2014,2015,2016,2017,2018,2019 Security Onion Solutions, LLC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+. /usr/sbin/so-common-status
+
+if [ "$LOGSTASH_OUTPUT_REDIS" = "yes" ]; then
+        if pgrep redis-server > /dev/null; then
+        	REDIS_COUNT=$(redis-cli llen logstash:redis | awk '{print $1}')
+		echo "Records in queue: $REDIS_COUNT"
+	else
+		fail
+		echo "Redis is not running.  Try starting it with 'so-redis-start'"
+	fi
+fi

--- a/usr/sbin/so-redis-count
+++ b/usr/sbin/so-redis-count
@@ -20,7 +20,7 @@
 if [ "$LOGSTASH_OUTPUT_REDIS" = "yes" ]; then
         if pgrep redis-server > /dev/null; then
         	REDIS_COUNT=$(redis-cli llen logstash:redis | awk '{print $1}')
-		echo "Records in queue: $REDIS_COUNT"
+		echo "$REDIS_COUNT"
 	else
 		fail
 		echo "Redis is not running.  Try starting it with 'so-redis-start'"


### PR DESCRIPTION
Add script to provide redis queue count so users don't have to remember Redis syntax.