### PR TITLE
Disable Disk-based Shard Allocation

### DIFF
--- a/etc/elasticsearch/elasticsearch.yml
+++ b/etc/elasticsearch/elasticsearch.yml
@@ -8,3 +8,5 @@ discovery.zen.minimum_master_nodes: 1
 # This is a test -- if this is here, then the volume is mounted correctly.
 path.logs: /var/log/elasticsearch
 action.destructive_requires_name: true
+# Disable Disk-based Shard Allocation to prevent disk watermark errors.
+cluster.routing.allocation.disk.threshold_enabled: false


### PR DESCRIPTION
Disk space that is allocated to Elasticsearch is controlled by securityonion.conf and curator.  If Disk-based Shard Allocation is enabled, it leads to disk watermark errors and indices being locked as read-only when disk usage hits 90%.  Since Security Onion configures each Elasticsearch instance as a single node cluster, the index can never be moved to another node.  This results in data being lost and not ingested into Elasticsearch.  This only becomes a problem with larger disk sizes when users want to utilize greater than 90% of their disk.

Reference: https://www.elastic.co/guide/en/elasticsearch/reference/6.7/disk-allocator.html

There are mentions of this error in documentation currently that do not address why it happens or how to prevent it.  Documentation is also missing the last recovery step: curl command to set: `"index.blocks.read_only_allow_delete": null` on the affected indices. 
Documentation page: https://github.com/Security-Onion-Solutions/security-onion/wiki/Logstash