### PR TITLE
bypass initial prompt when calling soup

### DIFF
--- a/usr/sbin/so-elastic-features
+++ b/usr/sbin/so-elastic-features
@@ -58,6 +58,6 @@ fi
 echo "Please wait while switching to Elastic Features."
 
 sed -i 's|^DOCKERHUB="securityonionsolutions|DOCKERHUB="securityonionsolutionselas|g' $ELASTICDOWNLOAD
-echo | soup
+( echo; cat ) | soup # auto-respond to first prompt only
 
 header "Once containers have started, you should have access to Elastic Features."

--- a/usr/sbin/so-elastic-features
+++ b/usr/sbin/so-elastic-features
@@ -58,6 +58,6 @@ fi
 echo "Please wait while switching to Elastic Features."
 
 sed -i 's|^DOCKERHUB="securityonionsolutions|DOCKERHUB="securityonionsolutionselas|g' $ELASTICDOWNLOAD
-soup -y
+soup
 
 header "Once containers have started, you should have access to Elastic Features."

--- a/usr/sbin/so-elastic-features
+++ b/usr/sbin/so-elastic-features
@@ -58,6 +58,6 @@ fi
 echo "Please wait while switching to Elastic Features."
 
 sed -i 's|^DOCKERHUB="securityonionsolutions|DOCKERHUB="securityonionsolutionselas|g' $ELASTICDOWNLOAD
-soup
+echo | soup
 
 header "Once containers have started, you should have access to Elastic Features."


### PR DESCRIPTION
By calling soup with the -y flag here, it will not prompt before rebooting; the system will just disconnect.  If the state of the system is not such that it will survive a reboot, you've just caused an administrative headache.